### PR TITLE
feat: add maze submission and WebSocket integration

### DIFF
--- a/front-end/.env
+++ b/front-end/.env
@@ -1,0 +1,1 @@
+VITE_WEBSOCKET_URL=ws://localhost:5000


### PR DESCRIPTION
This PR adds the ability to submit a maze from the frontend to the backend via WebSocket. Users can input a maze, set the start (A) and end (B) points, and click "Run Maze" to send it. The WebSocket connection transmits the maze as a JSON payload, for example:
```json
{
"maze": [
[0,1,0,0,0],
[0,0,1,1,0],
[1,0,0,0,0],
[0,1,1,0,1],
[0,0,0,0,0]
],
"start": [0, 0],
"end": [4, 4]
}
```
This lays the foundation for the next change for this sprint, which will create nodes capable of receiving the maze and printing it to a CSV file.