### PR TITLE
feat: add elapsed time timer to simulation

### DIFF
--- a/front-end/src/App.tsx
+++ b/front-end/src/App.tsx
@@ -85,6 +85,7 @@ function App() {
           onBack={() => {
             setShowActivity(false);
             setShowBuilder(true);
+            setMessageQueue([]);
           }}
           messageQueue={messageQueue}
           maze={maze}

--- a/front-end/src/components/AgentActivity.test.tsx
+++ b/front-end/src/components/AgentActivity.test.tsx
@@ -224,7 +224,7 @@ describe('AgentActivity Component', () => {
       await waitFor(() => {
         const timeElement = document.querySelector('.activity-log-time');
         expect(timeElement).toBeInTheDocument();
-        expect(timeElement?.textContent).toMatch(/\d{2}:\d{2}:\d{2}/);
+        expect(timeElement?.textContent).toMatch(/\d{2}:\d{2}\.\d{3}/);
       });
     });
   });

--- a/front-end/src/components/AgentActivity.tsx
+++ b/front-end/src/components/AgentActivity.tsx
@@ -101,6 +101,16 @@ function ExpandIcon() {
   return <i className="bi bi-arrows-angle-expand" style={{ fontSize: '20px' }}></i>;
 }
 
+// For timestamp, converts a start timestamp into a MM:SS.ms elapsed string
+const getElapsed = (startTime: number | null): string => {
+  if (!startTime) return '00:00.000';
+  const elapsed = Date.now() - startTime;
+  const m = Math.floor(elapsed / 60000);
+  const s = Math.floor((elapsed % 60000) / 1000);
+  const ms = elapsed % 1000;
+  return `${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}.${ms.toString().padStart(3, '0')}`;
+};
+
 export default function AgentActivity({
   onBack,
   messageQueue,
@@ -118,6 +128,16 @@ export default function AgentActivity({
   const [flashingCells, setFlashingCells] = useState<Set<string>>(new Set());
   const discoveredCellsRef = useRef<Set<string>>(new Set());
   const processedCount = useRef(0);
+  const [elapsedTime, setElapsedTime] = useState('00:00.000');
+  const timerIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const timerStartRef = useRef<number | null>(null);
+
+  // Clear the interval on unmount to prevent memory leaks
+  useEffect(() => {
+    return () => {
+      if (timerIntervalRef.current) clearInterval(timerIntervalRef.current);
+    };
+  }, []);
 
   // Internal coordinates are [row, col]; display as (x, y) => (col, row).
   const formatCoordinate = (position: [number, number]): string => {
@@ -305,6 +325,13 @@ export default function AgentActivity({
     }
 
     else if (data.type === 'simulation_complete') {
+      // Stop the timer and snap to the exact final elapsed time
+      if (timerIntervalRef.current) {
+        clearInterval(timerIntervalRef.current);
+        timerIntervalRef.current = null;
+      }
+      setElapsedTime(getElapsed(timerStartRef.current));
+
       const result = data.goal_reached ? 'Success ✓' : 'Failed ✗';
       const ticks = data.tick ?? 'unknown';
       const exploredCells = data.explored_cells ?? 0;
@@ -375,6 +402,12 @@ export default function AgentActivity({
     }
 
     else if (data.type === 'ack') {
+      // Start the elapsed timer when the backend acknowledges the simulation
+      timerStartRef.current = Date.now();
+      timerIntervalRef.current = setInterval(() => {
+        setElapsedTime(getElapsed(timerStartRef.current));
+      }, 100);
+
       const newLog: ActivityLog = {
         id: `log-${Date.now()}-${Math.random()}`,
         timestamp,
@@ -391,15 +424,11 @@ export default function AgentActivity({
     const unprocessed = messageQueue.slice(processedCount.current);
     if (unprocessed.length === 0) return;
 
+    const timestamp = getElapsed(timerStartRef.current);
+
     unprocessed.forEach(msg => {
       try {
         const data = JSON.parse(msg);
-        const timestamp = new Date().toLocaleTimeString('en-US', {
-          hour12: false,
-          hour: '2-digit',
-          minute: '2-digit',
-          second: '2-digit'
-        });
         processMessage(data, timestamp);
       } catch (err) {
         console.error('Error parsing backend message:', err);
@@ -534,6 +563,7 @@ export default function AgentActivity({
           exploredPct={exploredPct}
           discoveredCells={discoveredCells}
           flashingCells={flashingCells}
+          elapsedTime={elapsedTime}
           onClose={() => setIsFullscreenMaze(false)}
         />
       )}

--- a/front-end/src/components/FullscreenMaze.tsx
+++ b/front-end/src/components/FullscreenMaze.tsx
@@ -18,6 +18,7 @@ interface FullscreenMazeProps {
   exploredPct: number;
   discoveredCells?: Set<string>;
   flashingCells?: Set<string>;
+  elapsedTime?: string;
   onClose: () => void;
 }
 
@@ -35,6 +36,7 @@ export default function FullscreenMaze({
   exploredPct,
   discoveredCells = new Set(),
   flashingCells = new Set(),
+  elapsedTime = '00:00.000',
   onClose
 }: FullscreenMazeProps) {
   return (
@@ -142,6 +144,7 @@ export default function FullscreenMaze({
               background: 'rgba(255, 255, 255, 0.03)',
               borderRadius: '6px'
             }}>
+              <span>Time: <strong style={{ color: '#fff' }}>{elapsedTime}</strong></span>
               <span>Tick: <strong style={{ color: '#fff' }}>{currentTick}</strong></span>
               <span>Explored: <strong style={{ color: '#fff' }}>{exploredPct}%</strong></span>
             </div>


### PR DESCRIPTION
Changed timestamp to time duration.

**Summary of Changes:**
- Changed activity log timestamps from wall clock time (HH:MM:SS) to elapsed simulation time (MM:SS.ms)
- Added interval-based elapsed timer that starts on ack and freezes on simulation_complete
- Pass elapsed time to FullscreenMaze component and display alongside tick and explored %
- Clear messageQueue on back navigation so next simulation starts fresh
- Updated test regex to match new timestamp format

**Files Changed:**
- src/components/AgentActivity.tsx
- src/components/FullscreenMaze.tsx
- src/components/AgentActivity.test.tsx
- src/App.tsx

Example:
<img width="1043" height="483" alt="fstime" src="https://github.com/user-attachments/assets/25996ed8-68f7-4fd7-87ca-55affa09b07c" />
<img width="1226" height="720" alt="aatime" src="https://github.com/user-attachments/assets/3c3d0c59-8a39-4a5d-8e38-26b9e520b441" />
