### PR TITLE
Remove backendMessage debug display from MazeBuilder

### DIFF
--- a/front-end/src/App.tsx
+++ b/front-end/src/App.tsx
@@ -124,7 +124,6 @@ function App() {
           }}
           onSendMaze={handleSendMaze}
           wsConnected={ws.current?.readyState === WebSocket.OPEN}
-          backendMessage={messageQueue[messageQueue.length - 1] ?? null}
           exportType={exportType}
           setExportType={setExportType}
           inputType={inputType}

--- a/front-end/src/components/MazeBuilder.tsx
+++ b/front-end/src/components/MazeBuilder.tsx
@@ -55,7 +55,6 @@ interface MazeBuilderProps {
   onBack: () => void;
   onSendMaze: (maze: number[][], start: [number, number], end: [number, number]) => void;
   wsConnected: boolean;
-  backendMessage?: string | null;
   exportType: 'csv' | 'json';
   setExportType: React.Dispatch<React.SetStateAction<'csv' | 'json'>>;
   inputType: 'csv' | 'json';
@@ -82,7 +81,6 @@ function MazeBuilder({
   onBack,
   onSendMaze,
   wsConnected,
-  backendMessage = null,
   exportType,
   setExportType,
   inputType,
@@ -324,25 +322,6 @@ function MazeBuilder({
               {maze ? (
                 <>
                   <MazeGrid maze={maze} start={startPt} end={endPt} />
-                  {backendMessage && (
-                    <div
-                      style={{
-                        marginTop: "1rem",
-                        padding: "0.75rem",
-                        background: "#111",
-                        color: "#0f0",
-                        fontFamily: "monospace",
-                        fontSize: "0.85rem",
-                        borderRadius: "6px",
-                        maxHeight: "200px",
-                        overflowY: "auto",
-                        width: "100%"
-                      }}
-                    >
-                      <b>Message from Node:</b>
-                      <pre style={{ margin: 0 }}>{backendMessage}</pre>
-                    </div>
-                  )}
                   <div style={{ width: '100%', display: 'flex', flexDirection: 'column', alignItems: 'center', marginTop: '1.5em' }}>
                     <Button className="button-run-maze" onClick={handleSendMaze}>Run Maze</Button>
                     <div className="export-btn-group">


### PR DESCRIPTION
Cleans up the temporary debug UI introduced in #58, where raw WebSocket messages from the backend were displayed inline in the MazeBuilder component after running a maze.

**Changes:**

- Removed backendMessage prop from MazeBuilderProps interface
- Removed backendMessage from MazeBuilder destructured props
- Removed the {backendMessage && (...)} debug display block from the maze preview UI
- Removed backendMessage prop passthrough in App.tsx

The messageQueue state and WebSocket message handling in App.tsx are retained as they are still consumed by AgentActivity.