### PR TITLE
feat: update configuration for deployment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Node.js (v18+ recommended)
 
 ### Setup Instructions
 
-1. Clone the repository from GitHub: ​​[https://github.com/bradfiep/CS.067-Self-Organizing-AI-Agents-at-the-Edge](https://github.com/bradfiep/CS.067-Self-Organizing-AI-Agents-at-the-Edge)   
+1. Clone the repository from GitHub: ​​[https://github.com/sarahsatchell/CS.067-Self-Organizing-AI-Agents-at-the-Edge](https://github.com/sarahsatchell/CS.067-Self-Organizing-AI-Agents-at-the-Edge)   
 2. Set up the frontend:
 
    cd frontend

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,54 +1,61 @@
 import asyncio
 import json
-import websockets
+import os
+from aiohttp import web
+import aiohttp
 import NodeClass
 from spawner import spawn_agents
 
 connected_clients = set()
-event_loop = None  
+event_loop = None
 
 
 # -------------------------
 # WebSocket handler (Frontend → Python)
 # -------------------------
-async def handler(websocket):
-    connected_clients.add(websocket)
+async def websocket_handler(request):
+    ws = web.WebSocketResponse(protocols=["chat"])
+    await ws.prepare(request)
+
+    connected_clients.add(ws)
     print("New client connected")
 
     try:
-        async for message in websocket:
-            data = json.loads(message)
-            maze = data.get("maze")
-            start = data.get("start")
-            end = data.get("end")
+        async for msg in ws:
+            if msg.type == aiohttp.WSMsgType.TEXT:
+                data = json.loads(msg.data)
+                maze = data.get("maze")
+                start = data.get("start")
+                end = data.get("end")
 
-            # Acknowledge receipt to the frontend
-            await websocket.send(json.dumps({
-                "type": "ack",
-                "status": "Maze received. Starting swarm simulation..."
-            }))
+                await ws.send_str(json.dumps({
+                    "type": "ack",
+                    "status": "Maze received. Starting swarm simulation..."
+                }))
 
-            # Trigger the live simulation directly
-            asyncio.create_task(run_live_simulation(maze, start, end, websocket))
+                asyncio.create_task(run_live_simulation(maze, start, end, ws))
 
-    except websockets.exceptions.ConnectionClosed:
-        print("Client disconnected")
+            elif msg.type == aiohttp.WSMsgType.ERROR:
+                print(f"WebSocket error: {ws.exception()}")
+
+    except Exception as e:
+        print(f"WebSocket handler error: {e}")
     finally:
-        connected_clients.remove(websocket)
+        connected_clients.discard(ws)
+        print("Client disconnected")
+
+    return ws
+
 
 # -------------------------
 # UDP Node listener (Node → Python)
 # -------------------------
 node = NodeClass.Node(9000, "Node1", 0)
 
+
 def on_udp_message(msg, addr):
     print(f"Node received message: {msg} from {addr}")
-
-    # Forward Node message to all WebSocket clients
-    asyncio.run_coroutine_threadsafe(
-        broadcast(msg),
-        event_loop
-    )
+    asyncio.run_coroutine_threadsafe(broadcast(msg), event_loop)
 
 
 node.on_message = on_udp_message
@@ -61,74 +68,58 @@ async def broadcast(message):
     if not connected_clients:
         return
 
-    # If message is already JSON, forward as-is
     try:
         payload = json.loads(message)
     except Exception:
-        payload = {
-            "type": "node_message",
-            "payload": message
-        }
+        payload = {"type": "node_message", "payload": message}
 
     msg_str = json.dumps(payload)
-
     await asyncio.gather(
-        *(ws.send(msg_str) for ws in connected_clients)
+        *(ws.send_str(msg_str) for ws in connected_clients),
+        return_exceptions=True
     )
 
 
 # -------------------------
-# Simulation logic (Node → Python → Frontend)
+# Simulation logic
 # -------------------------
-async def run_live_simulation(maze, start, end, websocket):
-    # 1. Spawn the swarm using your existing spawner logic
+async def run_live_simulation(maze, start, end, ws):
     agents = spawn_agents(maze, tuple(start))
-    
-    # Start UDP listeners for all agents so they can communicate with each other
+
     listener_tasks = [asyncio.create_task(agent.web_listen()) for agent in agents]
-    
-    # Register agents for frontend agent list
+
     for agent in agents:
-        await websocket.send(json.dumps({
+        await ws.send_str(json.dumps({
             "type": "agent_registered",
             "agent_name": agent.name,
             "agent_id": agent.agent_id,
             "position": list(agent.current_position),
             "status": "exploring"
         }))
-    
+
     tick = 0
     goal_reached = False
-    
-    # 2. Run the simulation loop
-    while not goal_reached and tick < 500: # Add a max_ticks failsafe
+
+    while not goal_reached and tick < 500:
         tick += 1
-        
-        # Array to hold the state of all agents for the frontend
         agent_data = []
-        
+
         for agent in agents:
-            # Execute the agent's logic for this tick
-            # Note: You may need to adapt this depending on how agent.tick() 
-            # receives the global/local view in your exact implementation
-            agent.tick(maze) 
-            
-            # Check if anyone found the end
+            agent.tick(maze)
+
             if agent.current_position == tuple(end):
                 goal_reached = True
                 if not agent.reached_goal:
                     agent.reached_goal = True
                     agent.goal_tick = tick
-                # Send log to frontend activity page
-                await websocket.send(json.dumps({
+                await ws.send_str(json.dumps({
                     "type": "agent_goal_reached",
                     "agent_name": agent.name,
                     "agent_id": agent.agent_id,
                     "position": list(agent.current_position),
                     "tick": tick
                 }))
-            
-            # Package the agent's current state
+
             agent_data.append({
                 "id": agent.agent_id,
                 "position": agent.current_position,
@@ -136,30 +127,24 @@ async def run_live_simulation(maze, start, end, websocket):
                 "cells_discovered": len(agent.local_map)
             })
 
-        # Calculate exploration percentage
         explored = set()
         for agent in agents:
             explored.update(agent.local_map.keys())
         total_open = sum(1 for row in maze for cell in row if cell == 0)
         explored_pct = (len(explored) / total_open * 100) if total_open > 0 else 0
 
-        # 3. Create the JSON payload for the frontend
-        payload = {
+        await ws.send_str(json.dumps({
             "type": "tick_update",
             "tick": tick,
             "goal_reached": goal_reached,
             "explored_pct": round(explored_pct, 1),
             "discovered_cell_positions": [list(cell) for cell in explored],
             "agents": agent_data
-        }
-        
-        # 4. Send the data to the frontend
-        await websocket.send(json.dumps(payload))
-        
-        # 5. Pause briefly to allow the frontend to render the frame smoothly
+        }))
+
         await asyncio.sleep(0.1)
-    
-    # Compute coverage across all agents and send simulation summary
+
+    # Final summary
     explored = set()
     for agent in agents:
         explored.update(agent.local_map.keys())
@@ -167,14 +152,12 @@ async def run_live_simulation(maze, start, end, websocket):
     total_open = sum(1 for row in maze for cell in row if cell == 0)
     explored_pct = (len(explored) / total_open * 100) if total_open > 0 else 0
 
-    # Collect stats for all agents
-    goal_tuple = tuple(end)
     agent_stats = []
     for agent in agents:
-        stats = agent.get_agent_stats(goal_tuple, maze, explored)
+        stats = agent.get_agent_stats(tuple(end), maze, explored)
         agent_stats.append(stats)
 
-    await websocket.send(json.dumps({
+    await ws.send_str(json.dumps({
         "type": "simulation_complete",
         "goal_reached": goal_reached,
         "tick": tick,
@@ -184,22 +167,45 @@ async def run_live_simulation(maze, start, end, websocket):
         "agent_stats": agent_stats
     }))
 
+
+# -------------------------
+# HTTP health check (HEAD is handled automatically by aiohttp for GET routes)
+# -------------------------
+async def health_check(request):
+    return web.Response(text="OK", status=200)
+
+
 # -------------------------
 # Main entry point
 # -------------------------
 async def main():
     global event_loop
-    event_loop = asyncio.get_running_loop()  
+    event_loop = asyncio.get_running_loop()
 
-    ws_server = await websockets.serve(handler, "0.0.0.0", 8080)
+    port = int(os.environ.get("PORT", "10000"))
+
+    app = web.Application()
+    app.router.add_get("/", health_check)
+    app.router.add_get("/ws", websocket_handler)
+
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "0.0.0.0", port)
+    await site.start()
+
     udp_listener = asyncio.create_task(node.web_listen())
 
-    print("🚀 WebSocket server running on ws://localhost:8080")
+    print(f"🚀 Server running on port {port}")
+    print(f"   Health check → GET /")
+    print(f"   WebSocket    → GET /ws")
 
-    await asyncio.gather(
-        ws_server.wait_closed(),
-        udp_listener
-    )
+    try:
+        await asyncio.gather(
+            asyncio.Event().wait(),
+            udp_listener
+        )
+    finally:
+        await runner.cleanup()
 
 
 if __name__ == "__main__":

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,1 @@
+aiohttp

--- a/front-end/src/components/footer.tsx
+++ b/front-end/src/components/footer.tsx
@@ -45,7 +45,7 @@ const Footer: React.FC = () => {
                     <span>Oregon State University</span>
                 </a>
 
-                <a href="https://github.com/bradfiep/CS.067-Self-Organizing-AI-Agents-at-the-Edge" style={linkStyle} aria-label="GitHub">
+                <a href="https://github.com/sarahsatchell/CS.067-Self-Organizing-AI-Agents-at-the-Edge" style={linkStyle} aria-label="GitHub">
                     <span>GitHub</span>
                     <img src="../src/assets/github_logo.png" alt="GitHub Logo" style={{ height: 40, verticalAlign: "middle" }} />
                 </a>

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,9 @@
+services:
+  - type: web
+    name: self-organizing-ai-backend
+    env: python
+    rootDir: .
+    plan: free
+    buildCommand: pip install -r backend/requirements.txt
+    startCommand: python3 backend/main.py
+    autoDeploy: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+-r backend/requirements.txt


### PR DESCRIPTION
**What was changed to get deployment working:**
Problem: We had two separate servers fighting over the same port — websockets library for WebSocket and aiohttp for HTTP. Render's health checker sent HEAD / to the WebSocket server which crashed it.

- Replaced the websockets library entirely with aiohttp's built-in WebSocket support so one server handles everything on one port
- Removed the duplicate app.router.add_route("HEAD", ...) line since aiohttp handles HEAD automatically
- Set VITE_WEBSOCKET_URL=wss://...onrender.com/ws as an env var on the frontend Render service so Vite could bake it into the build